### PR TITLE
Plat 1258/update recovery settings

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -143,7 +143,7 @@ func init() {
 
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeMaster, "can-be-master", true, "prevent keeper from being elected as master")
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeSynchronousReplica, "can-be-synchronous-replica", true, "prevent keeper from being chosen as synchronous replica")
-	CmdKeeper.PersistentFlags().BoolVar(&cfg.debug, "skip-render-hba", true, "boolean to render the hba configuration file even on restarts")
+	CmdKeeper.PersistentFlags().BoolVar(&cfg.debug, "skip-render-hba", false, "boolean to render the hba configuration file even on restarts")
 
 	if err := CmdKeeper.PersistentFlags().MarkDeprecated("id", "please use --uid"); err != nil {
 		log.Fatal(err)

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -514,7 +514,7 @@ func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
 
 		canBeMaster:             &cfg.canBeMaster,
 		canBeSynchronousReplica: &cfg.canBeSynchronousReplica,
-		skipRenderHBA: &cfg.skipRenderHBA,
+		skipRenderHBA: cfg.skipRenderHBA,
 
 		e:   e,
 		end: end,

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1488,7 +1488,6 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 			if db.Spec.SynchronousReplication {
 				p.waitSyncStandbysSynced = p.skipHBARender
 				log.Infow("not allowing connection as normal users since synchronous replication is enabled and instance was down")
-				log.Infof("L:1491 p.generateHBA(cd, db, %v)", p.skipHBARender)
 				pgm.SetHba(p.generateHBA(cd, db, p.skipHBARender))
 			}
 
@@ -1663,7 +1662,6 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	} else {
 		p.waitSyncStandbysSynced = false
 	}
-	log.Infof("L: 1666 not all sync standbys are synced p.generateHBA(cd, db, %v)", p.waitSyncStandbysSynced)
 	newHBA := p.generateHBA(cd, db, p.waitSyncStandbysSynced)
 	if !reflect.DeepEqual(newHBA, pgm.CurHba()) {
 		log.Infow("postgres hba entries changed, reloading postgres instance")
@@ -1845,7 +1843,6 @@ func (p *PostgresKeeper) generateHBA(cd *cluster.ClusterData, db *cluster.DB, on
 	if !onlyInternal {
 		// By default, if no custom pg_hba entries are provided, accept
 		// connections for all databases and users with md5 auth
-		log.Infof("generating pg_hba.conf file %v", onlyInternal)
 		if db.Spec.PGHBA != nil {
 			computedHBA = append(computedHBA, db.Spec.PGHBA...)
 		} else {

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -143,7 +143,7 @@ func init() {
 
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeMaster, "can-be-master", true, "prevent keeper from being elected as master")
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeSynchronousReplica, "can-be-synchronous-replica", true, "prevent keeper from being chosen as synchronous replica")
-	CmdKeeper.PersistentFlags().BoolVar(&cfg.skipHBARender, "skip-hba-render", false, "boolean to render the hba configuration file even on restarts")
+	CmdKeeper.PersistentFlags().BoolVar(&cfg.skipHBARender, "skip-hba-render", true, "boolean to render the hba configuration file even on restarts")
 
 	if err := CmdKeeper.PersistentFlags().MarkDeprecated("id", "please use --uid"); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Added flag to enable the skipping of the `pg_hba.conf` file defaulting to `true` meaning we do skip this generation, but have the option to generate it, if we want.